### PR TITLE
fix issue with clearing bit while analog stick is moving in a circle

### DIFF
--- a/Unity/Scripts/Runtime/Input/PlayerInputProcessor.cs
+++ b/Unity/Scripts/Runtime/Input/PlayerInputProcessor.cs
@@ -173,10 +173,10 @@ namespace SK.Libretro.Unity
                 (AnalogLeftX, AnalogLeftY) = ctx.ReadValue<Vector2>().ToShort(0x7fff);
                 if (AnalogDirectionsToDigital)
                 {
-                    _joypadButtons.SetBitIf((uint)RETRO_DEVICE_ID_JOYPAD.UP, AnalogLeftY > 0);
-                    _joypadButtons.SetBitIf((uint)RETRO_DEVICE_ID_JOYPAD.DOWN, AnalogLeftY < 0);
-                    _joypadButtons.SetBitIf((uint)RETRO_DEVICE_ID_JOYPAD.LEFT, AnalogLeftX > 0);
-                    _joypadButtons.SetBitIf((uint)RETRO_DEVICE_ID_JOYPAD.RIGHT, AnalogLeftX < 0);
+                    _joypadButtons.SetBit((uint)RETRO_DEVICE_ID_JOYPAD.UP, AnalogLeftY > 0);
+                    _joypadButtons.SetBit((uint)RETRO_DEVICE_ID_JOYPAD.DOWN, AnalogLeftY < 0);
+                    _joypadButtons.SetBit((uint)RETRO_DEVICE_ID_JOYPAD.LEFT, AnalogLeftX < 0);
+                    _joypadButtons.SetBit((uint)RETRO_DEVICE_ID_JOYPAD.RIGHT, AnalogLeftX > 0);
                 }
             };
             _inputActions.Emulation.AnalogLeft.canceled += ctx =>


### PR DESCRIPTION
with AnalogToDigital enabled, if a user used their stick and went to the upper left. The joybutton for up and left would be set. If the user then when to the bottom right, the down and right would be set, but the up and left would not be cleared as the `SetBitIf` function can only set bits. It will not clear them if the condition is false.

The left and right checks were also swapped.