### PR TITLE
add support with android (oculus quest)

### DIFF
--- a/Scripts/Core.cs
+++ b/Scripts/Core.cs
@@ -115,6 +115,7 @@ namespace SK.Libretro
                 case Platform.OSX:
                     _dll = new DynamicLibraryOSX(true);
                     break;
+                case Platform.Android:
                 case Platform.Linux:
                     _dll = new DynamicLibraryLinux(true);
                     break;
@@ -222,14 +223,28 @@ namespace SK.Libretro
         {
             try
             {
-                string corePath = $"{Wrapper.CoresDirectory}/{Name}_libretro.{_dll.Extension}";
+                string corePath;
+                switch (_wrapper.Settings.Platform)
+                {
+                    case Platform.Android:
+                        corePath = $"{Wrapper.CoresDirectory}/{Name}_libretro_android.{_dll.Extension}";
+                        break;
+                    case Platform.Win:
+                    case Platform.OSX:
+                    case Platform.Linux:
+                        corePath = $"{Wrapper.CoresDirectory}/{Name}_libretro.{_dll.Extension}";
+                        break;
+                    default:
+                        _wrapper.LogHandler.LogError($"Runtime platform '{_wrapper.Settings.Platform}' not supported.", "SK.Libretro.Core.Start");
+                        return false;
+                }
                 if (!FileSystem.FileExists(corePath))
                 {
                     _wrapper.LogHandler.LogError($"Core '{Name}' at path '{corePath}' not found.", "SK.Libretro.Core.LoadLibrary");
                     return false;
                 }
 
-                string instancePath = System.IO.Path.Combine(Wrapper.TempDirectory, $"{Name}_{Guid.NewGuid()}.{_dll.Extension}");
+                string instancePath = System.IO.Path.Combine($"{Wrapper.TempDirectory}", $"{Name}_{Guid.NewGuid()}.{_dll.Extension}");
                 File.Copy(corePath, instancePath);
 
                 _dll.Load(instancePath);

--- a/Scripts/InstanceHandler.cs
+++ b/Scripts/InstanceHandler.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Threading;
+
+namespace SK.Libretro
+{
+    abstract class InstanceHandler<T>
+    {
+        // IL2CPP does not support marshaling delegates that point to instance methods to native code.
+        // Using static method and per instance table.
+        private readonly Thread _thread;
+        private static Dictionary<Thread, T> instancePerHandle = new Dictionary<Thread, T>();
+
+        public InstanceHandler(T childClass)
+        {
+            _thread = Thread.CurrentThread;
+            lock(instancePerHandle)
+            {
+                instancePerHandle.Add(_thread, childClass);
+            }
+        }
+
+        ~InstanceHandler()
+        {
+            lock(instancePerHandle)
+            {
+                instancePerHandle.Remove(_thread);
+            }
+        }
+
+        protected static bool GetInstance(Thread thread, out T instance)
+        {
+            bool ok;
+            lock (instancePerHandle)
+            {
+                ok = instancePerHandle.TryGetValue(thread, out instance);
+            }
+            return ok;
+        }
+    }
+}

--- a/Scripts/InstanceHandler.cs.meta
+++ b/Scripts/InstanceHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ff10f418314bf2f4f9b97f399a9c1531
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Log/LogHandlerWin.cs
+++ b/Scripts/Log/LogHandlerWin.cs
@@ -39,59 +39,60 @@ namespace SK.Libretro
         {
         }
 
-        protected override void LogPrintf(retro_log_level level,
-                                          string format,
-                                          IntPtr arg1,
-                                          IntPtr arg2,
-                                          IntPtr arg3,
-                                          IntPtr arg4,
-                                          IntPtr arg5,
-                                          IntPtr arg6,
-                                          IntPtr arg7,
-                                          IntPtr arg8,
-                                          IntPtr arg9,
-                                          IntPtr arg10,
-                                          IntPtr arg11,
-                                          IntPtr arg12)
-        {
-            LogLevel logLevel = level.ToLogLevel();
-            if (logLevel < _level)
-                return;
+        // TODO: comment back in and workaround the 'static' issue
+        // protected override void LogPrintf(retro_log_level level,
+        //                                   string format,
+        //                                   IntPtr arg1,
+        //                                   IntPtr arg2,
+        //                                   IntPtr arg3,
+        //                                   IntPtr arg4,
+        //                                   IntPtr arg5,
+        //                                   IntPtr arg6,
+        //                                   IntPtr arg7,
+        //                                   IntPtr arg8,
+        //                                   IntPtr arg9,
+        //                                   IntPtr arg10,
+        //                                   IntPtr arg11,
+        //                                   IntPtr arg12)
+        // {
+        //     LogLevel logLevel = level.ToLogLevel();
+        //     if (logLevel < _level)
+        //         return;
 
-            int argumentsToPush;
-            try
-            {
-                argumentsToPush = GetFormatArgumentCount(format);
-            }
-            catch (NotImplementedException /*e*/)
-            {
-                //Log.Warning(e.Message);
-                return;
-            }
+        //     int argumentsToPush;
+        //     try
+        //     {
+        //         argumentsToPush = GetFormatArgumentCount(format);
+        //     }
+        //     catch (NotImplementedException /*e*/)
+        //     {
+        //         //Log.Warning(e.Message);
+        //         return;
+        //     }
 
-            if (argumentsToPush > 12)
-            {
-                LogWarning($"Too many arguments ({argumentsToPush}) supplied to retroLogCallback");
-                return;
-            }
+        //     if (argumentsToPush > 12)
+        //     {
+        //         LogWarning($"Too many arguments ({argumentsToPush}) supplied to retroLogCallback");
+        //         return;
+        //     }
 
-            Sprintf(out string formattedString,
-                    format,
-                    argumentsToPush >= 1 ? arg1 : IntPtr.Zero,
-                    argumentsToPush >= 2 ? arg2 : IntPtr.Zero,
-                    argumentsToPush >= 3 ? arg3 : IntPtr.Zero,
-                    argumentsToPush >= 4 ? arg4 : IntPtr.Zero,
-                    argumentsToPush >= 5 ? arg5 : IntPtr.Zero,
-                    argumentsToPush >= 6 ? arg6 : IntPtr.Zero,
-                    argumentsToPush >= 7 ? arg7 : IntPtr.Zero,
-                    argumentsToPush >= 8 ? arg8 : IntPtr.Zero,
-                    argumentsToPush >= 9 ? arg9 : IntPtr.Zero,
-                    argumentsToPush >= 10 ? arg10 : IntPtr.Zero,
-                    argumentsToPush >= 11 ? arg11 : IntPtr.Zero,
-                    argumentsToPush >= 12 ? arg12 : IntPtr.Zero);
+        //     Sprintf(out string formattedString,
+        //             format,
+        //             argumentsToPush >= 1 ? arg1 : IntPtr.Zero,
+        //             argumentsToPush >= 2 ? arg2 : IntPtr.Zero,
+        //             argumentsToPush >= 3 ? arg3 : IntPtr.Zero,
+        //             argumentsToPush >= 4 ? arg4 : IntPtr.Zero,
+        //             argumentsToPush >= 5 ? arg5 : IntPtr.Zero,
+        //             argumentsToPush >= 6 ? arg6 : IntPtr.Zero,
+        //             argumentsToPush >= 7 ? arg7 : IntPtr.Zero,
+        //             argumentsToPush >= 8 ? arg8 : IntPtr.Zero,
+        //             argumentsToPush >= 9 ? arg9 : IntPtr.Zero,
+        //             argumentsToPush >= 10 ? arg10 : IntPtr.Zero,
+        //             argumentsToPush >= 11 ? arg11 : IntPtr.Zero,
+        //             argumentsToPush >= 12 ? arg12 : IntPtr.Zero);
 
-            LogMessage(logLevel, formattedString);
-        }
+        //     LogMessage(logLevel, formattedString);
+        // }
 
         private static int GetFormatArgumentCount(string format)
         {

--- a/Scripts/PerfHandler.cs
+++ b/Scripts/PerfHandler.cs
@@ -47,19 +47,34 @@ namespace SK.Libretro
             _perf_log         = PerfLog;
         }
 
-        private long GetTimeUsec() => 0;
+        public class MonoPInvokeCallbackAttribute : System.Attribute
+        {
+            private Type type;
+            public MonoPInvokeCallbackAttribute(Type t) { type = t; }
+        }
 
-        private ulong GetCpuFeatures() => 0;
+        private delegate void VoidCallbackDelegate();
+        [MonoPInvokeCallbackAttribute(typeof(VoidCallbackDelegate))]
+        private static long GetTimeUsec() => 0;
 
-        private ulong GetPerfCounter() => 0;
+        [MonoPInvokeCallbackAttribute(typeof(VoidCallbackDelegate))]
+        private static ulong GetCpuFeatures() => 0;
 
-        private void PerfRegister(ref retro_perf_counter counter) { }
+        [MonoPInvokeCallbackAttribute(typeof(VoidCallbackDelegate))]
+        private static ulong GetPerfCounter() => 0;
 
-        private void PerfStart(ref retro_perf_counter counter) { }
+        private delegate void PerfCallbackDelegate(ref retro_perf_counter counter);
+        [MonoPInvokeCallbackAttribute(typeof(PerfCallbackDelegate))]
+        private static void PerfRegister(ref retro_perf_counter counter) { }
 
-        private void PerfStop(ref retro_perf_counter counter) { }
+        [MonoPInvokeCallbackAttribute(typeof(PerfCallbackDelegate))]
+        private static void PerfStart(ref retro_perf_counter counter) { }
 
-        private void PerfLog() { }
+        [MonoPInvokeCallbackAttribute(typeof(PerfCallbackDelegate))]
+        private static void PerfStop(ref retro_perf_counter counter) { }
+
+        [MonoPInvokeCallbackAttribute(typeof(VoidCallbackDelegate))]
+        private static void PerfLog() { }
 
         public bool GetPerfInterface(IntPtr data)
         {

--- a/Scripts/Utilities/FileSystem.cs
+++ b/Scripts/Utilities/FileSystem.cs
@@ -98,6 +98,11 @@ namespace SK.Libretro
             }
         }
 
+        public static string[] GetDirectoriesInDirectory(string path, string searchPattern, bool includeSubFolders = false)
+        {
+            return Directory.GetDirectories(path, searchPattern);
+        }
+
         public static void SerializeToJson<T>(T sourceObject, string targetPath)
         {
             try

--- a/Scripts/Wrapper.cs
+++ b/Scripts/Wrapper.cs
@@ -84,7 +84,7 @@ namespace SK.Libretro
                 OptionsDirectory     = FileSystem.GetOrCreateDirectory($"{_mainDirectory}/core_options");
                 SavesDirectory       = FileSystem.GetOrCreateDirectory($"{_mainDirectory}/saves");
                 StatesDirectory      = FileSystem.GetOrCreateDirectory($"{_mainDirectory}/states");
-                TempDirectory        = FileSystem.GetOrCreateDirectory($"{_mainDirectory}/temp");
+                TempDirectory        = FileSystem.GetOrCreateDirectory(!string.IsNullOrWhiteSpace(settings.TempDirectory) ? settings.TempDirectory : $"{_mainDirectory}/temp");
             }
 
             Core = new(this);

--- a/Scripts/WrapperSettings.cs
+++ b/Scripts/WrapperSettings.cs
@@ -26,18 +26,19 @@ namespace SK.Libretro
     {
         public readonly Platform Platform;
 
-        public LogLevel LogLevel                    { get; init; } = LogLevel.Warning;
-        public string MainDirectory                 { get; init; } = "";
-        public Language Language                    { get; init; } = Language.English;
-        public string UserName                      { get; init; } = "Default User";
-        public bool UseCoreRotation                 { get; init; }
-        public bool CropOverscan                    { get; init; } = true;
-        public ILogProcessor LogProcessor           { get; init; }
-        public IGraphicsProcessor GraphicsProcessor { get; init; }
-        public IAudioProcessor AudioProcessor       { get; init; }
-        public IInputProcessor InputProcessor       { get; init; }
-        public ILedProcessor LedProcessor           { get; init; }
-        public IMessageProcessor MessageProcessor   { get; init; }
+        public LogLevel LogLevel                    { get; set; } = LogLevel.Warning;
+        public string MainDirectory                 { get; set; } = "";
+        public string TempDirectory                 { get; set; } = "";
+        public Language Language                    { get; set; } = Language.English;
+        public string UserName                      { get; set; } = "Default User";
+        public bool UseCoreRotation                 { get; set; }
+        public bool CropOverscan                    { get; set; } = true;
+        public ILogProcessor LogProcessor           { get; set; }
+        public IGraphicsProcessor GraphicsProcessor { get; set; }
+        public IAudioProcessor AudioProcessor       { get; set; }
+        public IInputProcessor InputProcessor       { get; set; }
+        public ILedProcessor LedProcessor           { get; set; }
+        public IMessageProcessor MessageProcessor   { get; set; }
 
         public WrapperSettings(Platform platform) => Platform = platform;
     }

--- a/Unity/Scripts/Runtime/LibretroInstance.cs
+++ b/Unity/Scripts/Runtime/LibretroInstance.cs
@@ -29,15 +29,17 @@ namespace SK.Libretro.Unity
     [DisallowMultipleComponent]
     public sealed class LibretroInstance : MonoBehaviour
     {
-        [field: SerializeField] public Camera Camera { get; private set; }
-        [field: SerializeField, Layer] public int LightgunRaycastLayer { get; private set; }
-        [field: SerializeField] public Renderer Renderer { get; private set; }
-        [field: SerializeField] public Collider Collider { get; private set; }
-        [field: SerializeField] public Transform Viewer { get; private set; }
-        [field: SerializeField] public InstanceSettings Settings { get; private set; }
-        [field: SerializeField] public string CoreName { get; private set; }
-        [field: SerializeField] public string GamesDirectory { get; private set; }
-        [field: SerializeField] public string[] GameNames { get; private set; }
+        [field: SerializeField] public Camera Camera { get; set; }
+        [field: SerializeField, Layer] public int LightgunRaycastLayer { get; set; }
+        [field: SerializeField] public Renderer Renderer { get; set; }
+        [field: SerializeField] public Collider Collider { get; set; }
+        [field: SerializeField] public Transform Viewer { get; set; }
+        [field: SerializeField] public InstanceSettings Settings { get; set; }
+        [field: SerializeField] public string TempDirectory { get; set; }
+        [field: SerializeField] public string LibretroDirectory { get; set; }
+        [field: SerializeField] public string CoreName { get; set; }
+        [field: SerializeField] public string GamesDirectory { get; set; }
+        [field: SerializeField] public string[] GameNames { get; set; }
 
         public event Action OnInstanceStarted;
         public event Action OnInstanceStopped;
@@ -92,18 +94,22 @@ namespace SK.Libretro.Unity
 
         private void OnDisable() => StopContent();
 
-        public void Initialize(string coreName, string gamesDirectory, params string[] gameNames)
+        public void Initialize(string libretroDirectory, string tempDirectory, string coreName, string gamesDirectory, params string[] gameNames)
         {
-            CoreName       = coreName;
-            GamesDirectory = gamesDirectory;
-            GameNames      = gameNames;
+            LibretroDirectory = libretroDirectory;
+            TempDirectory     = tempDirectory;
+            CoreName          = coreName;
+            GamesDirectory    = gamesDirectory;
+            GameNames         = gameNames;
         }
 
         public void DeInitialize()
         {
-            CoreName       = null;
-            GamesDirectory = null;
-            GameNames      = null;
+            LibretroDirectory = null;
+            TempDirectory     = null;
+            CoreName          = null;
+            GamesDirectory    = null;
+            GameNames         = null;
         }
 
         public void StartContent()
@@ -112,7 +118,7 @@ namespace SK.Libretro.Unity
                 return;
 
             _bridge = new(this);
-            _bridge.StartContent(CoreName, GamesDirectory, GameNames, OnInstanceStarted, OnInstanceStopped);
+            _bridge.StartContent(LibretroDirectory, TempDirectory, CoreName, GamesDirectory, GameNames, OnInstanceStarted, OnInstanceStopped);
         }
 
         public void PauseContent() => _bridge?.PauseContent();


### PR DESCRIPTION
Android (Native Quest 2) builds use IL2CPP on unity. This presents an issue where having the error is given
```
IL2CPP does not support marshaling delegates that point to instance methods to native code. The method we're attempting to marshal is: SK.Libretro.EnvironmentHandler::EnvironmentCallback
```
The workaround is to having the functions be declared as `static` and are looked up within a Dictionary for the class instance with 'Thread' as it's index.

Android also has a limitation with where it can dynamically link in code The *.so library file of a libretro core just can not be from any location on the filesystem for 'security reasons'. The location must be within a specific directory. In this case, that directory is with in a temp location. Where `tempDirectory` in this case initialized to `$"{GetAndroidPrivateAppDataPath()}/temp"` and `libretroDirectory is initialized to `$"{Application.persistentDataPath}/libretro"`. GetAndroidPrivateAppDataPath() is shown below.
```cs
private string GetAndroidPrivateAppDataPath()
{
    string path;
    using (AndroidJavaClass jc = new AndroidJavaClass("com.unity3d.player.UnityPlayer"))
    {
        using (AndroidJavaObject currentActivity = jc.GetStatic<AndroidJavaObject>("currentActivity"))
        {
            path = currentActivity.Call<AndroidJavaObject>("getFilesDir").Call<string>("getCanonicalPath");
        }
    }
    return path;
}
```

Fixes #10 