### PR TITLE
attempt to improve crackling in audio

### DIFF
--- a/Unity/Scripts/Runtime/Audio/AudioProcessor.cs
+++ b/Unity/Scripts/Runtime/Audio/AudioProcessor.cs
@@ -20,20 +20,80 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE. */
 
+using NAudio.Utils;
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using Unity.Collections;
 using Unity.Jobs;
+using Unity.Mathematics;
 using UnityEngine;
 
 namespace SK.Libretro.Unity
 {
+    public class CircularBuffer<T>
+    {
+        private T[] buffer;
+        private int head;
+        private int tail;
+
+        public CircularBuffer(int capacity)
+        {
+            buffer = new T[capacity];
+            head = 0;
+            tail = 0;
+        }
+
+        public int Count
+        {
+            get { return tail >= head ? tail - head : buffer.Length - (head - tail); }
+        }
+
+        public int Capacity
+        {
+            get { return buffer.Length; }
+        }
+
+        public void Enqueue(T item)
+        {
+            buffer[tail] = item;
+            tail = (tail + 1) % buffer.Length;
+            if (tail == head)
+            {
+                head = (head + 1) % buffer.Length;
+            }
+        }
+
+        public T Dequeue()
+        {
+            if (Count == 0)
+                throw new InvalidOperationException("Buffer is empty");
+            T item = buffer[head];
+            head = (head + 1) % buffer.Length;
+            return item;
+        }
+
+        public void Clear()
+        {
+            head = 0;
+            tail = 0;
+        }
+
+        public T this[int index]
+        {
+            get { return buffer[(head + index) % buffer.Length]; }
+            set { buffer[(head + index) % buffer.Length] = value; }
+        }
+    }
+
     [RequireComponent(typeof(AudioSource)), DisallowMultipleComponent]
     internal sealed class AudioProcessor: MonoBehaviour, IAudioProcessor
     {
-        private const int AUDIO_BUFFER_SIZE = 65536;
+        private const int AUDIO_BUFFER_SIZE = 262144;
+        private const int CIRCULAR_BUFFER_SIZE = AUDIO_BUFFER_SIZE * 2;
 
-        private readonly List<float> _audioBufferList = new(AUDIO_BUFFER_SIZE);
+        private readonly List<float> _audioBufferList = new List<float>(AUDIO_BUFFER_SIZE);
+        private CircularBuffer<float> _circularBuffer = new CircularBuffer<float>(CIRCULAR_BUFFER_SIZE);
 
         private AudioSource _audioSource;
         private int _inputSampleRate;
@@ -46,17 +106,20 @@ namespace SK.Libretro.Unity
 
         private void OnAudioFilterRead(float[] data, int channels)
         {
-            if (_audioBufferList.Count < data.Length)
+            if (_circularBuffer.Count < data.Length)
                 return;
 
+            // Read samples from circular buffer
             for (int i = 0; i < data.Length; ++i)
-                data[i] = _audioBufferList[i];
-
-            _audioBufferList.RemoveRange(0, data.Length);
+            {
+                data[i] = _circularBuffer.Dequeue();
+            }
         }
+
 
         public void Init(int sampleRate) => MainThreadDispatcher.Enqueue(() =>
         {
+            Debug.Log($"Set sample to {sampleRate}");
             _inputSampleRate  = sampleRate;
             _outputSampleRate = AudioSettings.outputSampleRate;
 
@@ -67,6 +130,7 @@ namespace SK.Libretro.Unity
             if (_samples.IsCreated)
                 _samples.Dispose();
 
+            _circularBuffer.Clear();
             _audioSource.Play();
         });
 
@@ -90,23 +154,28 @@ namespace SK.Libretro.Unity
             _audioBufferList.AddRange(_samples);
         });
 
-        public unsafe void ProcessSampleBatch(IntPtr data, nuint frames) => MainThreadDispatcher.Enqueue(() =>
+        public unsafe void ProcessSampleBatch(IntPtr data, nuint frames)
         {
+            if ((_inputSampleRate == 0) || (_outputSampleRate == 0))
+                return;
+
             if (!_jobHandle.IsCompleted)
                 _jobHandle.Complete();
+            //Debug.Log($"Sample Rate: in:{_inputSampleRate}Hz out:{_outputSampleRate}Hz");
+            double ratio = (double)_outputSampleRate / (double)_inputSampleRate;
+            int numSourceFrames = (int)frames * 2;
+            int numDestFrames = (int)((double)(numSourceFrames) * ratio);
+            //Debug.Log($"create buffer of {numDestFrames} from {frames} {ratio}");
+            CreateBuffer(numDestFrames);
 
-            int numFrames = (int)frames * 2;
-            CreateBuffer(numFrames);
-            _jobHandle = new SampleBatchJob
+            Resampler.LinearResample((short*)data, numSourceFrames, _samples, numDestFrames, _inputSampleRate, _outputSampleRate);
+
+            // Add samples to circular buffer
+            for (int i = 0; i < numDestFrames; i++)
             {
-                SourceSamples      = (short*)data,
-                DestinationSamples = _samples,
-                SourceSampleRate   = _inputSampleRate,
-                TargetSampleRate   = _outputSampleRate
-            }.Schedule(numFrames, 64);
-            _jobHandle.Complete();
-            _audioBufferList.AddRange(_samples);
-        });
+                _circularBuffer.Enqueue(_samples[i]);
+            }
+        }
 
         private void CreateBuffer(int numFrames)
         {

--- a/Unity/Scripts/Runtime/Audio/Resample.cs
+++ b/Unity/Scripts/Runtime/Audio/Resample.cs
@@ -1,0 +1,90 @@
+﻿/* MIT License
+
+ * Copyright (c) 2021-2022 Skurdt
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE. */
+
+using System;
+using Unity.Burst;
+using Unity.Collections;
+using Unity.Collections.LowLevel.Unsafe;
+using Unity.Jobs;
+using Unity.Mathematics;
+using UnityEngine;
+
+namespace SK.Libretro.Unity
+{
+    internal unsafe class Resampler
+    {
+        public static void LinearResample(short* sourceSamples, int sourceLength, NativeArray<float> destinationSamples,
+                                          int destinationLength, int sourceSampleRate, int targetSampleRate)
+        {
+            float ratio = (float)targetSampleRate / (float)sourceSampleRate;
+            int lastSourceSample = sourceLength - 1;
+            int lastDestinationSample = destinationLength - 1;
+
+            for (int i = 0; i < destinationSamples.Length; i++)
+            {
+                float sourceIndex = i / ratio;
+                int leftSampleIndex = Mathf.FloorToInt(sourceIndex);
+                int rightSampleIndex = Mathf.CeilToInt(sourceIndex);
+                float lerp = sourceIndex - leftSampleIndex;
+
+                if (rightSampleIndex > lastSourceSample)
+                {
+                    rightSampleIndex = lastSourceSample;
+                }
+
+                if (leftSampleIndex > lastSourceSample)
+                {
+                    leftSampleIndex = lastSourceSample;
+                }
+
+                destinationSamples[i] = Mathf.Lerp(sourceSamples[leftSampleIndex] * AudioHandler.NORMALIZED_GAIN,
+                                                  sourceSamples[rightSampleIndex] * AudioHandler.NORMALIZED_GAIN,
+                                                  lerp);
+            }
+        }
+
+        private static float CubicInterpolate(float v0, float v1, float v2, float v3, float x)
+        {
+            float P = (v3 - v2) - (v0 - v1);
+            float Q = (v0 - v1) - P;
+            float R = v2 - v0;
+            float S = v1;
+            return P * x * x * x + Q * x * x + R * x + S;
+        }
+
+        public static void CubicResample(short* sourceSamples, NativeArray<float> destinationSamples,
+                             int sourceSampleRate, int targetSampleRate, int index)
+        {
+            float sampleIndex = index * (float)sourceSampleRate / targetSampleRate;
+            int sampleIndex1 = (int)math.floor(sampleIndex);
+            int sampleIndex0 = math.clamp(sampleIndex1 - 1, 0, sourceSampleRate - 1);
+            int sampleIndex2 = math.clamp(sampleIndex1 + 1, 0, sourceSampleRate - 1);
+            int sampleIndex3 = math.clamp(sampleIndex1 + 2, 0, sourceSampleRate - 1);
+            float fractionalIndex = sampleIndex - sampleIndex1;
+            float v0 = sourceSamples[sampleIndex0] * AudioHandler.NORMALIZED_GAIN;
+            float v1 = sourceSamples[sampleIndex1] * AudioHandler.NORMALIZED_GAIN;
+            float v2 = sourceSamples[sampleIndex2] * AudioHandler.NORMALIZED_GAIN;
+            float v3 = sourceSamples[sampleIndex3] * AudioHandler.NORMALIZED_GAIN;
+            destinationSamples[index] = CubicInterpolate(v0, v1, v2, v3, fractionalIndex);
+        }
+    }
+}

--- a/Unity/Scripts/Runtime/Audio/Resample.cs.meta
+++ b/Unity/Scripts/Runtime/Audio/Resample.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3b73c734ee993da46aa5a5a24ddd57b0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
the issue here was that the destination buffer was using the same length as the source buffer and the destination buffer needs to be longer or shorter based on ratio between the input and output sample rates. This is still not a perfect solution and needs to be revisited for further improvement. [Draft PR for now]

Fixes #6 