### PR TITLE
Fix missing wrapper in bridge commands

### DIFF
--- a/Unity/Scripts/Runtime/Bridge.cs
+++ b/Unity/Scripts/Runtime/Bridge.cs
@@ -403,19 +403,19 @@ namespace SK.Libretro.Unity
             => _bridgeCommands.Enqueue(new SaveStateWithScreenshotBridgeCommand(_wrapper, TakeScreenshot));
 
         public void SaveStateWithoutScreenshot()
-            => _bridgeCommands.Enqueue(new SaveStateWithoutScreenshotBridgeCommand());
+            => _bridgeCommands.Enqueue(new SaveStateWithoutScreenshotBridgeCommand(_wrapper));
 
         public void LoadState()
-            => _bridgeCommands.Enqueue(new LoadStateBridgeCommand());
+            => _bridgeCommands.Enqueue(new LoadStateBridgeCommand(_wrapper));
 
         public void SetDiskIndex(int index)
             => _bridgeCommands.Enqueue(new SetDiskIndexBridgeCommand(_wrapper, _gamesDirectory, _gameNames, index));
 
         public void SaveSRAM()
-            => _bridgeCommands.Enqueue(new SaveSRAMBridgeCommand());
+            => _bridgeCommands.Enqueue(new SaveSRAMBridgeCommand(_wrapper));
 
         public void LoadSRAM()
-            => _bridgeCommands.Enqueue(new LoadSRAMBridgeCommand());
+            => _bridgeCommands.Enqueue(new LoadSRAMBridgeCommand(_wrapper));
 
         public void SaveOptions(bool global)
             => _bridgeCommands.Enqueue(new SaveOptionsBridgeCommand(_wrapper, global));


### PR DESCRIPTION
Hey @Skurdt , I fixed up these missing `_wrapper` initializations. I saw you added one (for LoadState) in your [latest PR](https://github.com/Skurdt/SK.Libretro/pull/35/changes), but it's missing on a few others.